### PR TITLE
[codex] fix public profile bugs

### DIFF
--- a/src/app/[slug]/_lib/get-page-data.ts
+++ b/src/app/[slug]/_lib/get-page-data.ts
@@ -228,12 +228,12 @@ function extractPreview(type: string, content: unknown): string {
     const html = typeof c.markdown === 'string' ? c.markdown : '';
     text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
   } else if (type === 'newspaper') {
+    const lead =
+      (Array.isArray(c?.pages) && c.pages[0]?.leadStory) || c?.leadStory;
     const headline =
-      typeof c?.leadStory?.headline === 'string' ? c.leadStory.headline : '';
+      typeof lead?.headline === 'string' ? lead.headline : '';
     const sub =
-      typeof c?.leadStory?.subheadline === 'string'
-        ? c.leadStory.subheadline
-        : '';
+      typeof lead?.subheadline === 'string' ? lead.subheadline : '';
     text = [headline, sub].filter(Boolean).join(' — ').trim();
   } else if (type === 'roast') {
     text = typeof c.roast === 'string' ? c.roast : '';

--- a/src/app/[slug]/layout.tsx
+++ b/src/app/[slug]/layout.tsx
@@ -36,5 +36,5 @@ export default async function SlugLayout({ params, children }: Props) {
   const data = await getFullPageData(slug);
   if (!data) notFound();
 
-  return <>{children}</>;
+  return <div data-karte-public-slug={slug}>{children}</div>;
 }

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -20,7 +20,6 @@ import { VideoEmbed } from '@/components/public/video-embed';
 import type { ProjectCardData } from '@/components/public/widgets';
 import { agentOperatorLabel, isAgentPage } from '@/lib/agent-profiles';
 import { isDemoSlug } from '@/lib/demo-profiles';
-import { getProfileVariant } from '@/lib/profile-variants';
 import { resolveThemeConfig } from '@/lib/themes';
 
 import { getFullPageData } from './_lib/get-page-data';
@@ -116,7 +115,6 @@ export default async function ProfilePage({ params }: Props) {
     modeContent,
   } = data;
   const theme = resolveThemeConfig(page.themeConfig);
-  const variant = getProfileVariant(undefined);
   const isAgent = isAgentPage(page);
   const operatorLabel = agentOperatorLabel(page);
 
@@ -266,7 +264,7 @@ export default async function ProfilePage({ params }: Props) {
               page.chatEnabled
                 ? isAgent
                   ? `Talk to ${page.displayName}`
-                  : variant.primaryCta
+                  : 'Start chat'
                 : 'Send a message'
             }
             calendarUrl={page.calendarUrl}

--- a/src/app/api/pages/[pageId]/generate/encyclopedia/route.ts
+++ b/src/app/api/pages/[pageId]/generate/encyclopedia/route.ts
@@ -5,6 +5,7 @@ import type { PageSettings } from '@/db/schema';
 import { generatedPages,pages, users } from '@/db/schema';
 import { generate, resolveAiConfig } from '@/lib/ai-client';
 import { ENCYCLOPEDIA_SYSTEM_PROMPT } from '@/lib/ai-prompts';
+import { getSession } from '@/lib/auth-server';
 import { asGeneratedPageContent, type EncyclopediaContent } from '@/lib/generated-page-types';
 import { buildProfileMemory } from '@/lib/profile-memory';
 import { rateLimit } from '@/lib/rate-limit';
@@ -12,6 +13,7 @@ import { parseAIResponse } from '@/lib/saasmaker';
 
 export async function POST(req: Request, { params }: { params: Promise<{ pageId: string }> }) {
   const { pageId } = await params;
+  const session = await getSession();
 
   const isBackgroundCall = req.headers.get('x-background-generation') === '1';
   if (!isBackgroundCall) {
@@ -20,9 +22,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     if (!ok) return new Response(JSON.stringify({ error: 'Too many requests' }), { status: 429 });
   }
 
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   await ensureProjectsTable();
 
-  const [page] = await db.select().from(pages).where(eq(pages.id, pageId));
+  const [page] = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.id, pageId), eq(pages.userId, session.user.id)));
   if (!page || !page.encyclopediaEnabled) {
     return new Response(JSON.stringify({ error: 'Encyclopedia not enabled' }), { status: 404 });
   }

--- a/src/app/api/pages/[pageId]/generate/newspaper/route.ts
+++ b/src/app/api/pages/[pageId]/generate/newspaper/route.ts
@@ -5,6 +5,7 @@ import type { PageSettings } from '@/db/schema';
 import { generatedPages,pages, users } from '@/db/schema';
 import { generate, resolveAiConfig } from '@/lib/ai-client';
 import { NEWSPAPER_SYSTEM_PROMPT } from '@/lib/ai-prompts';
+import { getSession } from '@/lib/auth-server';
 import { asGeneratedPageContent, type NewspaperContent } from '@/lib/generated-page-types';
 import { buildProfileMemory } from '@/lib/profile-memory';
 import { rateLimit } from '@/lib/rate-limit';
@@ -15,6 +16,7 @@ export async function POST(
   { params }: { params: Promise<{ pageId: string }> }
 ) {
   const { pageId } = await params;
+  const session = await getSession();
 
   const isBackgroundCall = req.headers.get('x-background-generation') === '1';
   if (!isBackgroundCall) {
@@ -29,9 +31,19 @@ export async function POST(
     }
   }
 
+  if (!session?.user?.id) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
   await ensureProjectsTable();
 
-  const [page] = await db.select().from(pages).where(eq(pages.id, pageId));
+  const [page] = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.id, pageId), eq(pages.userId, session.user.id)));
   if (!page || !page.newspaperEnabled) {
     return new Response(
       JSON.stringify({ error: 'Newspaper not enabled' }),

--- a/src/app/api/pages/[pageId]/generate/roast/route.ts
+++ b/src/app/api/pages/[pageId]/generate/roast/route.ts
@@ -5,6 +5,7 @@ import type { PageSettings } from '@/db/schema';
 import { generatedPages,pages, users } from '@/db/schema';
 import { generate, resolveAiConfig } from '@/lib/ai-client';
 import { ROAST_SYSTEM_PROMPT } from '@/lib/ai-prompts';
+import { getSession } from '@/lib/auth-server';
 import { asGeneratedPageContent, type RoastContent } from '@/lib/generated-page-types';
 import { buildProfileMemory } from '@/lib/profile-memory';
 import { rateLimit } from '@/lib/rate-limit';
@@ -15,6 +16,7 @@ export async function POST(
   { params }: { params: Promise<{ pageId: string }> }
 ) {
   const { pageId } = await params;
+  const session = await getSession();
 
   // Skip rate-limit for background generation triggered by the worker itself
   // (e.g. when a mode is toggled on in page-toggles → fire-and-forget regen).
@@ -31,10 +33,20 @@ export async function POST(
     }
   }
 
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   await ensureProjectsTable();
 
   // Get page and user
-  const [page] = await db.select().from(pages).where(eq(pages.id, pageId));
+  const [page] = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.id, pageId), eq(pages.userId, session.user.id)));
   if (!page || !page.roastEnabled) {
     return new Response(JSON.stringify({ error: 'Roast not enabled' }), {
       status: 404,

--- a/src/components/public/page-analytics-tracker.tsx
+++ b/src/components/public/page-analytics-tracker.tsx
@@ -39,14 +39,26 @@ function getProfileVariantFromLocation() {
   return new URLSearchParams(window.location.search).get('variant') || 'baseline';
 }
 
+function getAnalyticsSlug(pathname: string) {
+  const pathSlug = getPublicSlug(pathname);
+  if (pathSlug) {
+    return pathSlug;
+  }
+
+  const hint = document
+    .querySelector<HTMLElement>('[data-karte-public-slug]')
+    ?.dataset.kartePublicSlug;
+  return hint || null;
+}
+
 export function PageAnalyticsTracker() {
   const pathname = usePathname();
   const lastTrackedPath = useRef<string | null>(null);
 
   useEffect(() => {
-    const slug = getPublicSlug(pathname);
+    const slug = getAnalyticsSlug(pathname);
     const profileVariant = getProfileVariantFromLocation();
-    const trackedPath = `${pathname}?variant=${profileVariant}`;
+    const trackedPath = `${slug ?? pathname}?variant=${profileVariant}`;
     if (!slug || lastTrackedPath.current === trackedPath) {
       return;
     }
@@ -64,7 +76,7 @@ export function PageAnalyticsTracker() {
   }, [pathname]);
 
   useEffect(() => {
-    const analyticsSlug = getPublicSlug(pathname);
+    const analyticsSlug = getAnalyticsSlug(pathname);
     if (!analyticsSlug) {
       return;
     }

--- a/src/components/public/profile-hero.tsx
+++ b/src/components/public/profile-hero.tsx
@@ -1,6 +1,11 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
 import { OpenChatButton } from '@/components/public/open-chat-button';
 import { ProfileAvatar } from '@/components/public/profile-avatar';
 import { SocialIconRow } from '@/components/public/social-icon-row';
+import { getProfileVariant } from '@/lib/profile-variants';
 
 interface QuickAction {
   label: string;
@@ -75,6 +80,8 @@ export function ProfileHero({
     icon: string | null;
   }>;
 }) {
+  const searchParams = useSearchParams();
+  const selectedVariant = getProfileVariant(searchParams.get('variant'));
   const firstName = displayName.split(/\s+/)[0] || displayName;
   const restOfName = displayName.slice(firstName.length).trim();
   const initials =
@@ -170,15 +177,17 @@ export function ProfileHero({
 
       {/* Primary CTAs — stacked, not pills */}
       <div className="mt-7 flex flex-col gap-2">
-        {hasMessenger && !chatEnabled && (
+        {hasMessenger && (
           <OpenChatButton
-            mode="contact"
+            mode={chatEnabled ? 'chat' : 'contact'}
             className="group inline-flex items-center justify-between rounded-2xl px-5 py-3.5 text-[15px] font-semibold text-zinc-950 transition-all duration-200 ease-[var(--karte-ease)] hover:brightness-110 active:scale-[0.98]"
             style={{ backgroundColor: accentColor }}
           >
             <span className="flex items-center gap-2">
               <span aria-hidden="true">💬</span>
-              {primaryChatCta}
+              {selectedVariant.id === 'baseline'
+                ? primaryChatCta
+                : selectedVariant.primaryCta}
             </span>
             <span
               aria-hidden="true"

--- a/src/lib/hostname.ts
+++ b/src/lib/hostname.ts
@@ -30,6 +30,38 @@ export function normalizeHostname(input: string | null | undefined): string | nu
 // Karte's own brand domains — baked in because Next.js inlines NEXT_PUBLIC_*
 // env vars at build time, making runtime env var bridging unreliable.
 const KARTE_APP_HOSTS = new Set(['karte.cc', 'www.karte.cc']);
+const MULTI_PART_PUBLIC_SUFFIXES = new Set([
+  'co.uk',
+  'org.uk',
+  'ac.uk',
+  'gov.uk',
+  'com.au',
+  'net.au',
+  'org.au',
+  'co.nz',
+  'com.br',
+  'com.mx',
+  'co.jp',
+  'ne.jp',
+  'or.jp',
+  'co.kr',
+  'com.cn',
+  'com.sg',
+  'co.in',
+  'in',
+]);
+
+function isApexHostname(hostname: string): boolean {
+  const parts = hostname.toLowerCase().split('.');
+  if (parts.length <= 2) return true;
+
+  const suffix = parts.slice(-2).join('.');
+  if (MULTI_PART_PUBLIC_SUFFIXES.has(suffix)) {
+    return parts.length === 3;
+  }
+
+  return false;
+}
 
 export function isAppHost(host: string, appHost: string | null | undefined): boolean {
   if (!host) return false;
@@ -75,7 +107,7 @@ export function getCustomDomainCnameTarget(): string {
 
 export function getDnsInstructions(hostname: string): DnsInstruction[] {
   const target = getCustomDomainCnameTarget();
-  const isApex = hostname.split('.').length === 2;
+  const isApex = isApexHostname(hostname);
   if (isApex) {
     return [
       {

--- a/tests/hostname.unit.test.mjs
+++ b/tests/hostname.unit.test.mjs
@@ -5,6 +5,26 @@ import { test } from 'node:test';
 // runs without a TS compile step. If src/lib/hostname.ts changes, mirror here.
 
 const HOSTNAME_RE = /^(?=.{1,253}$)(?!-)(?:[a-z0-9-]{1,63}(?<!-)\.)+[a-z]{2,63}$/;
+const MULTI_PART_PUBLIC_SUFFIXES = new Set([
+  'co.uk',
+  'org.uk',
+  'ac.uk',
+  'gov.uk',
+  'com.au',
+  'net.au',
+  'org.au',
+  'co.nz',
+  'com.br',
+  'com.mx',
+  'co.jp',
+  'ne.jp',
+  'or.jp',
+  'co.kr',
+  'com.cn',
+  'com.sg',
+  'co.in',
+  'in',
+]);
 
 function normalizeHostname(input) {
   if (typeof input !== 'string') return null;
@@ -45,9 +65,21 @@ function isAppHost(host, appHost) {
   return false;
 }
 
+function isApexHostname(hostname) {
+  const parts = hostname.toLowerCase().split('.');
+  if (parts.length <= 2) return true;
+
+  const suffix = parts.slice(-2).join('.');
+  if (MULTI_PART_PUBLIC_SUFFIXES.has(suffix)) {
+    return parts.length === 3;
+  }
+
+  return false;
+}
+
 function getDnsInstructions(hostname) {
   const target = 'linkchat.sarthakagrawal927.workers.dev';
-  const isApex = hostname.split('.').length === 2;
+  const isApex = isApexHostname(hostname);
   if (isApex) {
     return [
       {
@@ -129,4 +161,11 @@ test('getDnsInstructions returns single CNAME for subdomain', () => {
   assert.equal(recs.length, 1);
   assert.equal(recs[0].type, 'CNAME');
   assert.equal(recs[0].name, 'blog');
+});
+
+test('getDnsInstructions handles public-suffix apex domains', () => {
+  const recs = getDnsInstructions('example.co.uk');
+  assert.equal(recs.length, 2);
+  assert.equal(recs[0].name, '@');
+  assert.equal(recs[1].name, 'www');
 });


### PR DESCRIPTION
## What changed
- Added ownership checks to the encyclopedia, roast, and newspaper generation routes so a caller must own the page before regenerating content.
- Fixed public-profile analytics so custom-domain pages and nested mode pages resolve the real slug for `page_view` and outbound click tracking.
- Wired the profile hero variant CTA to the `variant` query param again, and made the CTA visible for chat-enabled pages.
- Fixed newspaper preview extraction for the newer multi-page content shape.
- Improved custom-domain DNS instructions so apex domains like `example.co.uk` are classified correctly.

## Why
These surfaces were silently incorrect in ways that affect real users: unauthorized regeneration, missing analytics, stale variant previews, blank newspaper previews, and wrong DNS instructions.

## Checks
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (warnings only; no errors)
