### PR TITLE
[codex] fix dm activity label

### DIFF
--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -220,6 +220,8 @@ export default async function AnalyticsPage() {
                             ? 'Section viewed'
                             : event.eventType === 'contact_submit'
                               ? 'Lead captured'
+                              : event.eventType === 'dm_submit'
+                                ? 'Direct message sent'
                               : event.eventType === 'hook_open'
                                 ? 'Chat widget opened'
                                 : event.eventType === 'chat_cta_click'


### PR DESCRIPTION
## What changed
- Label `dm_submit` events as "Direct message sent" in dashboard recent activity.

## Why
`dm_submit` is a real direct-message submission event, but the analytics page was falling through to the generic "Outbound click" label. That makes the recent activity feed misleading for DM-heavy pages.

## Checks
- `pnpm exec eslint src/app/dashboard/analytics/page.tsx`
