### PR TITLE
fix(agent-auth): clarify sign-in code email instructions for UI flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ SAASMAKER_ADMIN_KEY=
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Agent API email (Resend). Without RESEND_API_KEY, codes log to the server console in dev.
+RESEND_API_KEY=
+EMAIL_FROM=Karte <noreply@karte.cc>
+
 # PostHog (internal product analytics)
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/migrations/d1/006_agent_trust_cards.sql
+++ b/migrations/d1/006_agent_trust_cards.sql
@@ -1,0 +1,42 @@
+-- Agent trust cards: page subtype fields, API keys, and auth codes.
+
+ALTER TABLE pages ADD COLUMN pageType TEXT NOT NULL DEFAULT 'person';
+ALTER TABLE pages ADD COLUMN verifiedDomain TEXT;
+ALTER TABLE pages ADD COLUMN verifiedAt INTEGER;
+ALTER TABLE pages ADD COLUMN verificationMethod TEXT;
+ALTER TABLE pages ADD COLUMN verificationToken TEXT;
+ALTER TABLE pages ADD COLUMN agentPurpose TEXT;
+ALTER TABLE pages ADD COLUMN agentOperator TEXT;
+ALTER TABLE pages ADD COLUMN agentOperatorUrl TEXT;
+ALTER TABLE pages ADD COLUMN agentCapabilities TEXT;
+ALTER TABLE pages ADD COLUMN agentDisclosurePolicy TEXT;
+ALTER TABLE pages ADD COLUMN brainEndpointUrl TEXT;
+ALTER TABLE pages ADD COLUMN brainEndpointAuth TEXT;
+ALTER TABLE pages ADD COLUMN brainEndpointShape TEXT DEFAULT 'openai-chat';
+
+CREATE INDEX IF NOT EXISTS idx_pages_pageType ON pages (pageType);
+CREATE INDEX IF NOT EXISTS idx_pages_userId_pageType ON pages (userId, pageType);
+
+CREATE TABLE IF NOT EXISTS apiKeys (
+  id TEXT PRIMARY KEY NOT NULL,
+  userId TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  keyPrefix TEXT NOT NULL,
+  keyHash TEXT NOT NULL UNIQUE,
+  createdAt INTEGER NOT NULL,
+  revokedAt INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_apiKeys_userId ON apiKeys (userId);
+CREATE INDEX IF NOT EXISTS idx_apiKeys_keyHash ON apiKeys (keyHash);
+
+CREATE TABLE IF NOT EXISTS agentAuthCodes (
+  id TEXT PRIMARY KEY NOT NULL,
+  email TEXT NOT NULL,
+  codeHash TEXT NOT NULL,
+  expiresAt INTEGER NOT NULL,
+  createdAt INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agentAuthCodes_email ON agentAuthCodes (email);
+CREATE INDEX IF NOT EXISTS idx_agentAuthCodes_expiresAt ON agentAuthCodes (expiresAt);

--- a/src/app/[slug]/agent.json/route.ts
+++ b/src/app/[slug]/agent.json/route.ts
@@ -1,0 +1,34 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db, ensureProjectsTable } from '@/db';
+import { pages } from '@/db/schema';
+import { buildAgentManifest } from '@/lib/agent-pages';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await ctx.params;
+  await ensureProjectsTable();
+
+  const [page] = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.slug, slug), eq(pages.pageType, 'agent'), eq(pages.published, true)));
+
+  if (!page) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const origin = process.env.NEXT_PUBLIC_APP_URL || 'https://karte.cc';
+  const manifest = buildAgentManifest(page, origin);
+
+  return NextResponse.json(manifest, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+    },
+  });
+}

--- a/src/app/api/auth/agent/request-code/route.ts
+++ b/src/app/api/auth/agent/request-code/route.ts
@@ -1,0 +1,73 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db } from '@/db';
+import { agentAuthCodes } from '@/db/schema';
+import { generateAuthCode, hashSecret } from '@/lib/agent-crypto';
+import { sendAgentAuthCode } from '@/lib/agent-email';
+import { rateLimit } from '@/lib/rate-limit';
+import { isValidEmail } from '@/lib/validation';
+
+const CODE_TTL_MS = 10 * 60 * 1000;
+
+export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const ipLimit = rateLimit(`agent-auth:ip:${ip}`, { maxRequests: 10, windowMs: 60 * 60 * 1000 });
+  if (!ipLimit.ok) {
+    return NextResponse.json(
+      { error: 'Too many requests', retry_after: 3600 },
+      { status: 429, headers: { 'Retry-After': '3600' } },
+    );
+  }
+
+  let body: { email?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 });
+  }
+
+  const emailLimit = rateLimit(`agent-auth:email:${email}`, {
+    maxRequests: 3,
+    windowMs: 10 * 60 * 1000,
+  });
+  if (!emailLimit.ok) {
+    return NextResponse.json(
+      { error: 'Too many code requests for this email', retry_after: 600 },
+      { status: 429, headers: { 'Retry-After': '600' } },
+    );
+  }
+
+  const code = generateAuthCode();
+  const codeHash = await hashSecret(code);
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CODE_TTL_MS);
+
+  await db.delete(agentAuthCodes).where(eq(agentAuthCodes.email, email));
+  await db.insert(agentAuthCodes).values({
+    id: crypto.randomUUID(),
+    email,
+    codeHash,
+    expiresAt,
+    createdAt: now,
+  });
+
+  try {
+    await sendAgentAuthCode(email, code);
+  } catch (error) {
+    console.error('[agent-auth] failed to send code email', error);
+    return NextResponse.json({ error: 'Could not send sign-in email' }, { status: 502 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    email,
+    expires_in_seconds: CODE_TTL_MS / 1000,
+    message: 'Sign-in code sent. Check your email.',
+  });
+}

--- a/src/app/api/auth/agent/verify-code/route.ts
+++ b/src/app/api/auth/agent/verify-code/route.ts
@@ -1,0 +1,75 @@
+import { and, eq, gt } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db } from '@/db';
+import { agentAuthCodes } from '@/db/schema';
+import { createApiKey, findOrCreateOperator } from '@/lib/agent-api-auth';
+import { hashSecret } from '@/lib/agent-crypto';
+import { rateLimit } from '@/lib/rate-limit';
+import { isValidEmail } from '@/lib/validation';
+
+export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const ipLimit = rateLimit(`agent-auth-verify:ip:${ip}`, {
+    maxRequests: 20,
+    windowMs: 60 * 60 * 1000,
+  });
+  if (!ipLimit.ok) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
+  let body: { email?: unknown; code?: unknown; keyName?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  const keyName =
+    typeof body.keyName === 'string' && body.keyName.trim()
+      ? body.keyName.trim().slice(0, 64)
+      : `agent-${crypto.randomUUID().slice(0, 8)}`;
+
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 });
+  }
+
+  if (!/^\d{6}$/.test(code)) {
+    return NextResponse.json({ error: 'A 6-digit code is required' }, { status: 400 });
+  }
+
+  const now = new Date();
+  const codeHash = await hashSecret(code);
+  const [stored] = await db
+    .select()
+    .from(agentAuthCodes)
+    .where(
+      and(
+        eq(agentAuthCodes.email, email),
+        eq(agentAuthCodes.codeHash, codeHash),
+        gt(agentAuthCodes.expiresAt, now),
+      ),
+    )
+    .limit(1);
+
+  if (!stored) {
+    return NextResponse.json({ error: 'Invalid or expired code' }, { status: 401 });
+  }
+
+  await db.delete(agentAuthCodes).where(eq(agentAuthCodes.email, email));
+
+  const operator = await findOrCreateOperator(email);
+  const { row, rawKey } = await createApiKey(operator.id, keyName);
+
+  return NextResponse.json({
+    apiKey: rawKey,
+    apiKeyId: row.id,
+    userId: operator.id,
+    email: operator.email,
+    keyName,
+    docs_url: `${process.env.NEXT_PUBLIC_APP_URL || 'https://karte.cc'}/llms.txt`,
+    message: 'Save this API key now. It will not be shown again.',
+  });
+}

--- a/src/app/api/v1/agents/[slug]/publish/route.ts
+++ b/src/app/api/v1/agents/[slug]/publish/route.ts
@@ -1,0 +1,86 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db, ensureProjectsTable } from '@/db';
+import { pages } from '@/db/schema';
+import { authenticateApiKey } from '@/lib/agent-api-auth';
+import { sanitizeAgentPageResponse } from '@/lib/agent-pages';
+
+function getOrigin(req: Request) {
+  return process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await authenticateApiKey(req.headers.get('authorization'));
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  await ensureProjectsTable();
+
+  const page = await db.query.pages.findFirst({
+    where: and(
+      eq(pages.slug, slug),
+      eq(pages.userId, auth.userId),
+      eq(pages.pageType, 'agent'),
+    ),
+  });
+
+  if (!page) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const now = new Date();
+  const [updated] = await db
+    .update(pages)
+    .set({ published: true, updatedAt: now })
+    .where(eq(pages.id, page.id))
+    .returning();
+
+  const origin = getOrigin(req);
+  return NextResponse.json({
+    agent: sanitizeAgentPageResponse(updated),
+    urls: {
+      profile: `${origin}/${updated.slug}`,
+      manifest: `${origin}/${updated.slug}/agent.json`,
+    },
+  });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await authenticateApiKey(req.headers.get('authorization'));
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  await ensureProjectsTable();
+
+  const page = await db.query.pages.findFirst({
+    where: and(
+      eq(pages.slug, slug),
+      eq(pages.userId, auth.userId),
+      eq(pages.pageType, 'agent'),
+    ),
+  });
+
+  if (!page) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const now = new Date();
+  const [updated] = await db
+    .update(pages)
+    .set({ published: false, updatedAt: now })
+    .where(eq(pages.id, page.id))
+    .returning();
+
+  return NextResponse.json({ agent: sanitizeAgentPageResponse(updated) });
+}

--- a/src/app/api/v1/agents/[slug]/route.ts
+++ b/src/app/api/v1/agents/[slug]/route.ts
@@ -1,0 +1,172 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db, ensureProjectsTable } from '@/db';
+import { pages } from '@/db/schema';
+import { authenticateApiKey } from '@/lib/agent-api-auth';
+import {
+  MAX_AGENT_DISCLOSURE_LENGTH,
+  MAX_AGENT_OPERATOR_LENGTH,
+  MAX_AGENT_PURPOSE_LENGTH,
+  normalizeAgentCapabilities,
+  sanitizeAgentPageResponse,
+} from '@/lib/agent-pages';
+import { isValidUrl, MAX_TITLE_LENGTH } from '@/lib/validation';
+
+function getOrigin(req: Request) {
+  return process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+}
+
+async function loadOwnedAgent(slug: string, userId: string) {
+  return db.query.pages.findFirst({
+    where: and(eq(pages.slug, slug), eq(pages.userId, userId), eq(pages.pageType, 'agent')),
+  });
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await authenticateApiKey(req.headers.get('authorization'));
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  await ensureProjectsTable();
+
+  const page = await loadOwnedAgent(slug, auth.userId);
+  if (!page) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const origin = getOrigin(req);
+  return NextResponse.json({
+    agent: sanitizeAgentPageResponse(page),
+    urls: {
+      profile: `${origin}/${page.slug}`,
+      manifest: `${origin}/${page.slug}/agent.json`,
+    },
+  });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await authenticateApiKey(req.headers.get('authorization'));
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  await ensureProjectsTable();
+
+  const page = await loadOwnedAgent(slug, auth.userId);
+  if (!page) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const updates: Partial<typeof pages.$inferInsert> = {
+    updatedAt: new Date(),
+  };
+
+  if (body.displayName !== undefined) {
+    if (typeof body.displayName !== 'string' || !body.displayName.trim()) {
+      return NextResponse.json({ error: 'displayName must be a non-empty string' }, { status: 400 });
+    }
+    if (body.displayName.trim().length > MAX_TITLE_LENGTH) {
+      return NextResponse.json({ error: 'displayName is too long' }, { status: 400 });
+    }
+    updates.displayName = body.displayName.trim();
+  }
+
+  if (body.agentPurpose !== undefined) {
+    const value = typeof body.agentPurpose === 'string' ? body.agentPurpose.trim() : '';
+    if (value.length > MAX_AGENT_PURPOSE_LENGTH) {
+      return NextResponse.json({ error: 'agentPurpose is too long' }, { status: 400 });
+    }
+    updates.agentPurpose = value || null;
+    updates.bio = value || null;
+  }
+
+  if (body.agentOperator !== undefined) {
+    const value = typeof body.agentOperator === 'string' ? body.agentOperator.trim() : '';
+    if (value.length > MAX_AGENT_OPERATOR_LENGTH) {
+      return NextResponse.json({ error: 'agentOperator is too long' }, { status: 400 });
+    }
+    updates.agentOperator = value || null;
+  }
+
+  if (body.agentOperatorUrl !== undefined) {
+    const value = typeof body.agentOperatorUrl === 'string' ? body.agentOperatorUrl.trim() : '';
+    if (value && !isValidUrl(value)) {
+      return NextResponse.json({ error: 'agentOperatorUrl must be a valid URL' }, { status: 400 });
+    }
+    updates.agentOperatorUrl = value || null;
+  }
+
+  if (body.agentDisclosurePolicy !== undefined) {
+    const value =
+      typeof body.agentDisclosurePolicy === 'string' ? body.agentDisclosurePolicy.trim() : '';
+    if (value.length > MAX_AGENT_DISCLOSURE_LENGTH) {
+      return NextResponse.json({ error: 'agentDisclosurePolicy is too long' }, { status: 400 });
+    }
+    updates.agentDisclosurePolicy = value || null;
+  }
+
+  if (body.agentCapabilities !== undefined) {
+    const capabilities = normalizeAgentCapabilities(body.agentCapabilities);
+    if (capabilities === null) {
+      return NextResponse.json({ error: 'agentCapabilities must be a valid array' }, { status: 400 });
+    }
+    updates.agentCapabilities = capabilities;
+  }
+
+  if (body.avatarUrl !== undefined) {
+    const value = typeof body.avatarUrl === 'string' ? body.avatarUrl.trim() : '';
+    if (value && !isValidUrl(value)) {
+      return NextResponse.json({ error: 'avatarUrl must be a valid URL' }, { status: 400 });
+    }
+    updates.avatarUrl = value || null;
+  }
+
+  if (body.chatEnabled !== undefined) {
+    updates.chatEnabled = Boolean(body.chatEnabled);
+  }
+
+  if (body.brainEndpointUrl !== undefined) {
+    const value = typeof body.brainEndpointUrl === 'string' ? body.brainEndpointUrl.trim() : '';
+    if (value && !isValidUrl(value)) {
+      return NextResponse.json({ error: 'brainEndpointUrl must be a valid URL' }, { status: 400 });
+    }
+    updates.brainEndpointUrl = value || null;
+  }
+
+  if (body.brainEndpointAuth !== undefined) {
+    const value = typeof body.brainEndpointAuth === 'string' ? body.brainEndpointAuth.trim() : '';
+    updates.brainEndpointAuth = value || null;
+  }
+
+  const [updated] = await db
+    .update(pages)
+    .set(updates)
+    .where(eq(pages.id, page.id))
+    .returning();
+
+  const origin = getOrigin(req);
+  return NextResponse.json({
+    agent: sanitizeAgentPageResponse(updated),
+    urls: {
+      profile: `${origin}/${updated.slug}`,
+      manifest: `${origin}/${updated.slug}/agent.json`,
+    },
+  });
+}

--- a/src/app/api/v1/agents/route.ts
+++ b/src/app/api/v1/agents/route.ts
@@ -1,0 +1,171 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db, ensureProjectsTable } from '@/db';
+import { pages } from '@/db/schema';
+import { authenticateApiKey } from '@/lib/agent-api-auth';
+import {
+  MAX_AGENT_DISCLOSURE_LENGTH,
+  MAX_AGENT_OPERATOR_LENGTH,
+  MAX_AGENT_PURPOSE_LENGTH,
+  normalizeAgentCapabilities,
+  sanitizeAgentPageResponse,
+} from '@/lib/agent-pages';
+import { resolveThemeConfig } from '@/lib/themes';
+import { isValidSlug, isValidUrl, MAX_TITLE_LENGTH } from '@/lib/validation';
+
+function getOrigin(req: Request) {
+  return process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+}
+
+async function requireAgentAuth(req: Request) {
+  const auth = await authenticateApiKey(req.headers.get('authorization'));
+  if (!auth) {
+    return {
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    } as const;
+  }
+  return { auth } as const;
+}
+
+export async function GET(req: Request) {
+  const gate = await requireAgentAuth(req);
+  if ('error' in gate) return gate.error;
+
+  await ensureProjectsTable();
+
+  const rows = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.userId, gate.auth.userId), eq(pages.pageType, 'agent')));
+
+  return NextResponse.json({
+    agents: rows.map(sanitizeAgentPageResponse),
+  });
+}
+
+export async function POST(req: Request) {
+  const gate = await requireAgentAuth(req);
+  if ('error' in gate) return gate.error;
+
+  await ensureProjectsTable();
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const slug = typeof body.slug === 'string' ? body.slug.trim().toLowerCase() : '';
+  const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : '';
+
+  if (!slug || !displayName) {
+    return NextResponse.json({ error: 'slug and displayName are required' }, { status: 400 });
+  }
+
+  if (!isValidSlug(slug)) {
+    return NextResponse.json(
+      { error: 'Slug must be 3-50 chars, lowercase alphanumeric and hyphens only' },
+      { status: 400 },
+    );
+  }
+
+  if (displayName.length > MAX_TITLE_LENGTH) {
+    return NextResponse.json({ error: 'displayName is too long' }, { status: 400 });
+  }
+
+  const existing = await db.query.pages.findFirst({ where: eq(pages.slug, slug) });
+  if (existing) {
+    return NextResponse.json({ error: 'Slug is already taken' }, { status: 409 });
+  }
+
+  const agentPurpose =
+    typeof body.agentPurpose === 'string'
+      ? body.agentPurpose.trim()
+      : typeof body.bio === 'string'
+        ? body.bio.trim()
+        : null;
+
+  if (agentPurpose && agentPurpose.length > MAX_AGENT_PURPOSE_LENGTH) {
+    return NextResponse.json({ error: 'agentPurpose is too long' }, { status: 400 });
+  }
+
+  const agentOperator =
+    typeof body.agentOperator === 'string' ? body.agentOperator.trim() : null;
+  if (agentOperator && agentOperator.length > MAX_AGENT_OPERATOR_LENGTH) {
+    return NextResponse.json({ error: 'agentOperator is too long' }, { status: 400 });
+  }
+
+  const agentOperatorUrl =
+    typeof body.agentOperatorUrl === 'string' ? body.agentOperatorUrl.trim() : null;
+  if (agentOperatorUrl && !isValidUrl(agentOperatorUrl)) {
+    return NextResponse.json({ error: 'agentOperatorUrl must be a valid URL' }, { status: 400 });
+  }
+
+  const agentDisclosurePolicy =
+    typeof body.agentDisclosurePolicy === 'string'
+      ? body.agentDisclosurePolicy.trim()
+      : null;
+  if (agentDisclosurePolicy && agentDisclosurePolicy.length > MAX_AGENT_DISCLOSURE_LENGTH) {
+    return NextResponse.json({ error: 'agentDisclosurePolicy is too long' }, { status: 400 });
+  }
+
+  const capabilities = normalizeAgentCapabilities(body.agentCapabilities);
+  if (body.agentCapabilities !== undefined && capabilities === null) {
+    return NextResponse.json({ error: 'agentCapabilities must be a valid array' }, { status: 400 });
+  }
+
+  const avatarUrl = typeof body.avatarUrl === 'string' ? body.avatarUrl.trim() : null;
+  if (avatarUrl && !isValidUrl(avatarUrl)) {
+    return NextResponse.json({ error: 'avatarUrl must be a valid URL' }, { status: 400 });
+  }
+
+  const brainEndpointUrl =
+    typeof body.brainEndpointUrl === 'string' ? body.brainEndpointUrl.trim() : null;
+  if (brainEndpointUrl && !isValidUrl(brainEndpointUrl)) {
+    return NextResponse.json({ error: 'brainEndpointUrl must be a valid URL' }, { status: 400 });
+  }
+
+  const brainEndpointAuth =
+    typeof body.brainEndpointAuth === 'string' ? body.brainEndpointAuth.trim() : null;
+
+  const now = new Date();
+  const origin = getOrigin(req);
+
+  const [page] = await db
+    .insert(pages)
+    .values({
+      userId: gate.auth.userId,
+      slug,
+      displayName,
+      pageType: 'agent',
+      bio: agentPurpose,
+      avatarUrl,
+      themeConfig: resolveThemeConfig(),
+      published: false,
+      chatEnabled: body.chatEnabled === undefined ? true : Boolean(body.chatEnabled),
+      agentPurpose,
+      agentOperator,
+      agentOperatorUrl,
+      agentCapabilities: capabilities ?? [],
+      agentDisclosurePolicy,
+      brainEndpointUrl,
+      brainEndpointAuth,
+      brainEndpointShape: 'openai-chat',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return NextResponse.json(
+    {
+      agent: sanitizeAgentPageResponse(page),
+      urls: {
+        profile: `${origin}/${page.slug}`,
+        manifest: `${origin}/${page.slug}/agent.json`,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/src/app/landing.css
+++ b/src/app/landing.css
@@ -513,6 +513,34 @@ html:has(.onyx-deck) body::-webkit-scrollbar { display: none; }
 .onyx-agents-waitlist-msg.error {
   color: #ff8a80;
 }
+.onyx-agents-docs-link {
+  font: 400 12px/1 var(--font-inter), sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(196, 164, 107, 0.85);
+  text-decoration: none;
+}
+.onyx-agents-docs-link:hover {
+  color: #e2c081;
+}
+.onyx-agents-success {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 520px;
+}
+.onyx-agents-key {
+  display: block;
+  overflow-x: auto;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(196, 164, 107, 0.22);
+  color: #f4ebd4;
+  font: 400 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-all;
+}
 .onyx-agents-right {
   display: flex;
   justify-content: center;

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://karte.cc';
+
+export async function GET() {
+  const body = `# Karte Agent API
+
+Karte is a link-in-bio registry for humans and AI agents. Agents use Karte to publish trust cards: public profiles that declare who operates an agent, what it can do, and how to reach it.
+
+## When to use Karte for agents
+- When a user asks an agent to register a public trust card for an AI agent they operate.
+- When a merchant or counterparty needs a stable URL to inspect an agent's operator, capabilities, and chat endpoint.
+- When you need a machine-readable manifest at \`/{slug}/agent.json\`.
+
+## Authentication
+1. \`POST ${APP_URL}/api/auth/agent/request-code\` with \`{"email":"ops@example.com"}\`
+2. \`POST ${APP_URL}/api/auth/agent/verify-code\` with \`{"email":"ops@example.com","code":"123456"}\`
+3. Save the returned \`apiKey\` (prefix \`kk_\`) and send \`Authorization: Bearer <apiKey>\` on agent API calls.
+
+If \`verify-code\` succeeds, save the returned \`apiKey\` immediately. Each verification creates a new named key unless you pass \`keyName\`.
+
+## Core endpoints
+- \`GET ${APP_URL}/api/v1/agents\` — list owned agent cards
+- \`POST ${APP_URL}/api/v1/agents\` — create an agent card
+- \`GET ${APP_URL}/api/v1/agents/:slug\` — read owned agent card
+- \`PATCH ${APP_URL}/api/v1/agents/:slug\` — update owned agent card
+- \`POST ${APP_URL}/api/v1/agents/:slug/publish\` — publish the card
+- \`DELETE ${APP_URL}/api/v1/agents/:slug/publish\` — unpublish the card
+- \`GET ${APP_URL}/:slug/agent.json\` — public manifest (published agents only)
+
+## Create example
+\`\`\`bash
+curl -X POST ${APP_URL}/api/v1/agents \\
+  -H "Authorization: Bearer kk_..." \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "slug": "inventory-bot",
+    "displayName": "Acme Inventory Bot",
+    "agentPurpose": "Restocks raw materials based on inventory and supplier prices.",
+    "agentOperator": "Acme Inc.",
+    "agentOperatorUrl": "https://acme.com",
+    "agentCapabilities": [
+      {"id":"check_inventory","description":"Read current inventory levels"},
+      {"id":"place_order","description":"Place purchase orders up to $5000"}
+    ],
+    "chatEnabled": true
+  }'
+\`\`\`
+
+## Notes
+- Domain verification (verified operator badge) ships in the next phase.
+- Brain-proxy chat (forwarding visitor messages to the operator endpoint) ships in the next phase.
+- Unverified agent cards can still publish with an amber status on the public profile UI (coming soon).
+`;
+
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/src/components/landing/onyx-agents.tsx
+++ b/src/components/landing/onyx-agents.tsx
@@ -11,27 +11,23 @@ function capture(event: string, props?: Record<string, unknown>) {
   }
 }
 
+type AgentAuthState =
+  | { step: 'idle' }
+  | { step: 'email'; email: string; submitting: boolean; message: string; error: boolean }
+  | { step: 'code'; email: string; code: string; submitting: boolean; message: string; error: boolean }
+  | { step: 'done'; email: string; apiKey: string; docsUrl: string };
+
 /**
  * Card IV — For the agents, too.
  *
- * Left: pitch + waitlist CTA. Right: Atlas·4 mini sample agent card
- * with blue-foil edge.
- *
- * The CTA opens an inline email input that POSTs to /api/agent-waitlist
- * — agent subtype is on the build queue (4 weeks per docs/plans/agent-
- * subtype-spec.md) so until that ships the honest UX is a waitlist
- * rather than a 404.
+ * Operator email sign-in → API key → agent API docs.
  */
-type WaitlistState =
-  | { kind: 'closed' }
-  | { kind: 'open'; email: string; submitting: boolean; message: string; error: boolean };
-
 export function OnyxAgents() {
-  const [state, setState] = useState<WaitlistState>({ kind: 'closed' });
+  const [state, setState] = useState<AgentAuthState>({ step: 'idle' });
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function requestCode(e: React.FormEvent) {
     e.preventDefault();
-    if (state.kind !== 'open' || state.submitting) return;
+    if (state.step !== 'email' || state.submitting) return;
 
     const email = state.email.trim();
     if (!isValidEmail(email)) {
@@ -42,32 +38,79 @@ export function OnyxAgents() {
     setState({ ...state, submitting: true, message: '', error: false });
 
     try {
-      const res = await fetch('/api/agent-waitlist', {
+      const res = await fetch('/api/auth/agent/request-code', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       });
-      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      const data = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
       if (!res.ok) {
-        throw new Error(data.error || 'Could not save — try again.');
+        throw new Error(data.error || data.message || 'Could not send code.');
       }
+
+      capture('landing_agents_code_requested', { domain: email.split('@')[1] });
       setState({
-        kind: 'open',
+        step: 'code',
         email,
+        code: '',
         submitting: false,
-        message: 'You’re in. We’ll write when agent cards ship.',
+        message: 'Check your email for a 6-digit code.',
         error: false,
       });
-      capture('landing_agents_waitlist_submitted', { domain: email.split('@')[1] });
     } catch (err) {
       setState({
-        kind: 'open',
-        email,
+        ...state,
         submitting: false,
         message: err instanceof Error ? err.message : 'Something went wrong.',
         error: true,
       });
-      capture('landing_agents_waitlist_failed');
+      capture('landing_agents_code_request_failed');
+    }
+  }
+
+  async function verifyCode(e: React.FormEvent) {
+    e.preventDefault();
+    if (state.step !== 'code' || state.submitting) return;
+
+    const code = state.code.trim();
+    if (!/^\d{6}$/.test(code)) {
+      setState({ ...state, message: 'Enter the 6-digit code from your email.', error: true });
+      return;
+    }
+
+    setState({ ...state, submitting: true, message: '', error: false });
+
+    try {
+      const res = await fetch('/api/auth/agent/verify-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: state.email, code, keyName: 'landing' }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        apiKey?: string;
+        docs_url?: string;
+        message?: string;
+      };
+      if (!res.ok || !data.apiKey) {
+        throw new Error(data.error || data.message || 'Invalid code.');
+      }
+
+      capture('landing_agents_api_key_issued');
+      setState({
+        step: 'done',
+        email: state.email,
+        apiKey: data.apiKey,
+        docsUrl: data.docs_url || '/llms.txt',
+      });
+    } catch (err) {
+      setState({
+        ...state,
+        submitting: false,
+        message: err instanceof Error ? err.message : 'Something went wrong.',
+        error: true,
+      });
+      capture('landing_agents_verify_failed');
     }
   }
 
@@ -86,15 +129,15 @@ export function OnyxAgents() {
           you put on the open web.
         </p>
 
-        {state.kind === 'closed' ? (
+        {state.step === 'idle' ? (
           <div className="onyx-agents-actions">
             <button
               type="button"
               className="onyx-btn-primary"
               onClick={() => {
-                capture('landing_agents_waitlist_opened');
+                capture('landing_agents_auth_opened');
                 setState({
-                  kind: 'open',
+                  step: 'email',
                   email: '',
                   submitting: false,
                   message: '',
@@ -102,24 +145,31 @@ export function OnyxAgents() {
                 });
               }}
             >
-              Coming soon — notify me <span aria-hidden="true">→</span>
+              Get agent API key <span aria-hidden="true">→</span>
             </button>
+            <a className="onyx-agents-docs-link" href="/llms.txt">
+              Read agent API docs
+            </a>
           </div>
-        ) : (
+        ) : null}
+
+        {state.step === 'email' ? (
           <>
-            <form className="onyx-agents-waitlist" onSubmit={handleSubmit}>
+            <form className="onyx-agents-waitlist" onSubmit={requestCode}>
               <input
                 type="email"
                 inputMode="email"
                 autoComplete="email"
                 placeholder="you@operator.com"
                 value={state.email}
-                onChange={(e) => setState({ ...state, email: e.target.value, message: '', error: false })}
+                onChange={(e) =>
+                  setState({ ...state, email: e.target.value, message: '', error: false })
+                }
                 disabled={state.submitting}
                 required
               />
               <button type="submit" disabled={state.submitting || !state.email.trim()}>
-                {state.submitting ? 'Saving…' : 'Notify me'}
+                {state.submitting ? 'Sending…' : 'Send code'}
               </button>
             </form>
             {state.message ? (
@@ -128,11 +178,53 @@ export function OnyxAgents() {
               </p>
             ) : (
               <p className="onyx-agents-waitlist-msg">
-                Agent cards ship soon. Drop an email and we&rsquo;ll write when they&rsquo;re live.
+                Operator email only. We&apos;ll send a 6-digit sign-in code.
               </p>
             )}
           </>
-        )}
+        ) : null}
+
+        {state.step === 'code' ? (
+          <>
+            <form className="onyx-agents-waitlist" onSubmit={verifyCode}>
+              <input
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                placeholder="6-digit code"
+                value={state.code}
+                onChange={(e) =>
+                  setState({ ...state, code: e.target.value, message: '', error: false })
+                }
+                disabled={state.submitting}
+                required
+              />
+              <button type="submit" disabled={state.submitting || state.code.trim().length < 6}>
+                {state.submitting ? 'Verifying…' : 'Verify'}
+              </button>
+            </form>
+            {state.message ? (
+              <p className={`onyx-agents-waitlist-msg ${state.error ? 'error' : ''}`}>
+                {state.message}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {state.step === 'done' ? (
+          <div className="onyx-agents-success">
+            <p className="onyx-agents-waitlist-msg">
+              API key issued for <strong>{state.email}</strong>. Save it now — it won&apos;t be
+              shown again.
+            </p>
+            <code className="onyx-agents-key">{state.apiKey}</code>
+            <div className="onyx-agents-actions">
+              <a className="onyx-btn-primary" href={state.docsUrl}>
+                Open agent docs <span aria-hidden="true">→</span>
+              </a>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       <div className="onyx-agents-right">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,6 +13,18 @@ export type PageSettings = {
 
 export type DmMode = 'off' | 'anonymous' | 'email';
 
+export type PageType = 'person' | 'agent';
+
+export type AgentVerificationMethod = 'well-known' | 'dns-txt';
+
+export type BrainEndpointShape = 'openai-chat' | 'a2a' | 'webhook';
+
+export type AgentCapability = {
+  id: string;
+  label?: string;
+  description: string;
+};
+
 // ── User (better-auth default + linkchat custom fields) ──────────────
 // Table name `user` (singular) — matches better-auth defaults so its
 // drizzleAdapter resolves without a custom schema mapping.
@@ -116,6 +128,19 @@ export const pages = sqliteTable('pages', {
   // user can keep a real photo as the avatar and a character as pet.
   petUrl: text('petUrl'),
   petEnabled: integer('petEnabled', { mode: 'boolean' }).default(true),
+  pageType: text('pageType').$type<PageType>().notNull().default('person'),
+  verifiedDomain: text('verifiedDomain'),
+  verifiedAt: integer('verifiedAt', { mode: 'timestamp' }),
+  verificationMethod: text('verificationMethod').$type<AgentVerificationMethod>(),
+  verificationToken: text('verificationToken'),
+  agentPurpose: text('agentPurpose'),
+  agentOperator: text('agentOperator'),
+  agentOperatorUrl: text('agentOperatorUrl'),
+  agentCapabilities: text('agentCapabilities', { mode: 'json' }).$type<AgentCapability[]>(),
+  agentDisclosurePolicy: text('agentDisclosurePolicy'),
+  brainEndpointUrl: text('brainEndpointUrl'),
+  brainEndpointAuth: text('brainEndpointAuth'),
+  brainEndpointShape: text('brainEndpointShape').$type<BrainEndpointShape>().default('openai-chat'),
   createdAt: integer('createdAt', { mode: 'timestamp' }).$defaultFn(
     () => new Date(),
   ),
@@ -370,6 +395,30 @@ export const timelineEvents = sqliteTable('timelineEvents', {
 // Captured from card IV of the landing page until the agent subtype
 // ships (see docs/plans/agent-subtype-spec.md). One email per signup;
 // duplicates are deduped at insert via unique constraint on email.
+export const apiKeys = sqliteTable('apiKeys', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text('userId')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  keyPrefix: text('keyPrefix').notNull(),
+  keyHash: text('keyHash').notNull().unique(),
+  createdAt: integer('createdAt', { mode: 'timestamp' }).notNull(),
+  revokedAt: integer('revokedAt', { mode: 'timestamp' }),
+});
+
+export const agentAuthCodes = sqliteTable('agentAuthCodes', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  email: text('email').notNull(),
+  codeHash: text('codeHash').notNull(),
+  expiresAt: integer('expiresAt', { mode: 'timestamp' }).notNull(),
+  createdAt: integer('createdAt', { mode: 'timestamp' }).notNull(),
+});
+
 export const agentWaitlist = sqliteTable('agentWaitlist', {
   id: text('id')
     .primaryKey()

--- a/src/lib/agent-api-auth.ts
+++ b/src/lib/agent-api-auth.ts
@@ -1,0 +1,75 @@
+import 'server-only';
+
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { apiKeys, user } from '@/db/schema';
+
+import {
+  apiKeyPrefix,
+  generateApiKeyRaw,
+  hashSecret,
+  isApiKeyFormat,
+} from './agent-crypto';
+
+export async function authenticateApiKey(
+  authorization: string | null,
+): Promise<{ userId: string; apiKeyId: string } | null> {
+  if (!authorization?.startsWith('Bearer ')) return null;
+
+  const rawKey = authorization.slice('Bearer '.length).trim();
+  if (!isApiKeyFormat(rawKey)) return null;
+
+  const keyHash = await hashSecret(rawKey);
+  const row = await db.query.apiKeys.findFirst({
+    where: and(eq(apiKeys.keyHash, keyHash), isNull(apiKeys.revokedAt)),
+  });
+
+  if (!row) return null;
+  return { userId: row.userId, apiKeyId: row.id };
+}
+
+export async function createApiKey(userId: string, name: string) {
+  const rawKey = generateApiKeyRaw();
+  const keyHash = await hashSecret(rawKey);
+  const now = new Date();
+
+  const [row] = await db
+    .insert(apiKeys)
+    .values({
+      userId,
+      name,
+      keyPrefix: apiKeyPrefix(rawKey),
+      keyHash,
+      createdAt: now,
+    })
+    .returning();
+
+  return { row, rawKey };
+}
+
+export async function findOrCreateOperator(email: string) {
+  const normalized = email.trim().toLowerCase();
+  const existing = await db.query.user.findFirst({
+    where: eq(user.email, normalized),
+  });
+
+  if (existing) return existing;
+
+  const now = new Date();
+  const localPart = normalized.split('@')[0] ?? 'operator';
+
+  const [created] = await db
+    .insert(user)
+    .values({
+      id: crypto.randomUUID(),
+      name: localPart,
+      email: normalized,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return created;
+}

--- a/src/lib/agent-capabilities.ts
+++ b/src/lib/agent-capabilities.ts
@@ -1,0 +1,31 @@
+export type AgentCapability = {
+  id: string;
+  label?: string;
+  description: string;
+};
+
+export const MAX_AGENT_CAPABILITIES = 20;
+
+export function normalizeAgentCapabilities(value: unknown): AgentCapability[] | null {
+  if (value === undefined || value === null) return null;
+  if (!Array.isArray(value)) return null;
+
+  const normalized: AgentCapability[] = [];
+  for (const item of value.slice(0, MAX_AGENT_CAPABILITIES)) {
+    if (!item || typeof item !== 'object') return null;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === 'string' ? record.id.trim() : '';
+    const description =
+      typeof record.description === 'string' ? record.description.trim() : '';
+    const label = typeof record.label === 'string' ? record.label.trim() : undefined;
+
+    if (!id || !description) return null;
+    normalized.push({
+      id,
+      description,
+      ...(label ? { label } : {}),
+    });
+  }
+
+  return normalized;
+}

--- a/src/lib/agent-crypto.ts
+++ b/src/lib/agent-crypto.ts
@@ -1,0 +1,39 @@
+const API_KEY_PREFIX = 'kk_';
+
+function pepper(): string {
+  return process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET || 'karte-dev-pepper';
+}
+
+export async function hashSecret(value: string): Promise<string> {
+  const data = new TextEncoder().encode(`${pepper()}:${value}`);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function generateApiKeyRaw(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const body = btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${API_KEY_PREFIX}${body}`;
+}
+
+export function apiKeyPrefix(rawKey: string): string {
+  return rawKey.slice(0, 12);
+}
+
+export function isApiKeyFormat(value: string): boolean {
+  return value.startsWith(API_KEY_PREFIX) && value.length > API_KEY_PREFIX.length + 8;
+}
+
+export function generateAuthCode(): string {
+  const n = crypto.getRandomValues(new Uint32Array(1))[0]! % 1_000_000;
+  return n.toString().padStart(6, '0');
+}
+
+export { API_KEY_PREFIX };

--- a/src/lib/agent-email.ts
+++ b/src/lib/agent-email.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+
+export async function sendAgentAuthCode(email: string, code: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.EMAIL_FROM || 'Karte <noreply@karte.cc>';
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://karte.cc';
+
+  if (!apiKey) {
+    console.info(`[agent-auth] sign-in code for ${email}: ${code}`);
+    return;
+  }
+
+  const response = await fetch(RESEND_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from,
+      to: [email],
+      subject: `${code} is your Karte agent sign-in code`,
+      text: [
+        `Your Karte agent sign-in code is ${code}.`,
+        'It expires in 10 minutes.',
+        '',
+        `Use it at ${appUrl}/api/auth/agent/verify-code`,
+        '',
+        'If you did not request this, you can ignore this email.',
+      ].join('\n'),
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Failed to send sign-in email (${response.status}): ${body}`);
+  }
+}

--- a/src/lib/agent-email.ts
+++ b/src/lib/agent-email.ts
@@ -5,7 +5,6 @@ const RESEND_API_URL = 'https://api.resend.com/emails';
 export async function sendAgentAuthCode(email: string, code: string): Promise<void> {
   const apiKey = process.env.RESEND_API_KEY;
   const from = process.env.EMAIL_FROM || 'Karte <noreply@karte.cc>';
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://karte.cc';
 
   if (!apiKey) {
     console.info(`[agent-auth] sign-in code for ${email}: ${code}`);
@@ -26,7 +25,7 @@ export async function sendAgentAuthCode(email: string, code: string): Promise<vo
         `Your Karte agent sign-in code is ${code}.`,
         'It expires in 10 minutes.',
         '',
-        `Use it at ${appUrl}/api/auth/agent/verify-code`,
+        'Enter this code in the sign-in form on the page where you requested it.',
         '',
         'If you did not request this, you can ignore this email.',
       ].join('\n'),

--- a/src/lib/agent-pages.ts
+++ b/src/lib/agent-pages.ts
@@ -1,0 +1,62 @@
+import type { pages } from '@/db/schema';
+
+export { MAX_AGENT_CAPABILITIES, normalizeAgentCapabilities } from './agent-capabilities';
+export const MAX_AGENT_PURPOSE_LENGTH = 500;
+export const MAX_AGENT_OPERATOR_LENGTH = 100;
+export const MAX_AGENT_DISCLOSURE_LENGTH = 1_000;
+
+export type AgentPageRow = typeof pages.$inferSelect;
+
+export function buildAgentManifest(page: AgentPageRow, origin: string) {
+  const verified = Boolean(page.verifiedDomain && page.verifiedAt);
+
+  return {
+    slug: page.slug,
+    name: page.displayName,
+    purpose: page.agentPurpose ?? page.bio ?? null,
+    operator: {
+      name: page.agentOperator ?? null,
+      url: page.agentOperatorUrl ?? null,
+      verified,
+      verified_at: page.verifiedAt ? page.verifiedAt.toISOString() : null,
+      verified_domain: page.verifiedDomain ?? null,
+    },
+    capabilities: page.agentCapabilities ?? [],
+    chat: page.chatEnabled
+      ? {
+          url: `${origin}/api/chat/${page.slug}`,
+          shape: page.brainEndpointShape ?? 'openai-chat',
+        }
+      : null,
+    disclosure: page.agentDisclosurePolicy ?? null,
+    published: Boolean(page.published),
+    registry: origin,
+    manifest_url: `${origin}/${page.slug}/agent.json`,
+  };
+}
+
+export function sanitizeAgentPageResponse(page: AgentPageRow) {
+  return {
+    id: page.id,
+    slug: page.slug,
+    pageType: page.pageType,
+    displayName: page.displayName,
+    bio: page.bio,
+    avatarUrl: page.avatarUrl,
+    published: page.published,
+    chatEnabled: page.chatEnabled,
+    agentPurpose: page.agentPurpose,
+    agentOperator: page.agentOperator,
+    agentOperatorUrl: page.agentOperatorUrl,
+    agentCapabilities: page.agentCapabilities ?? [],
+    agentDisclosurePolicy: page.agentDisclosurePolicy,
+    brainEndpointUrl: page.brainEndpointUrl,
+    brainEndpointShape: page.brainEndpointShape,
+    hasBrainEndpointAuth: Boolean(page.brainEndpointAuth),
+    verifiedDomain: page.verifiedDomain,
+    verifiedAt: page.verifiedAt,
+    verificationMethod: page.verificationMethod,
+    createdAt: page.createdAt,
+    updatedAt: page.updatedAt,
+  };
+}

--- a/tests/agent-trust-cards.unit.test.mjs
+++ b/tests/agent-trust-cards.unit.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  generateApiKeyRaw,
+  generateAuthCode,
+  hashSecret,
+  isApiKeyFormat,
+} from '../src/lib/agent-crypto.ts';
+import { normalizeAgentCapabilities } from '../src/lib/agent-capabilities.ts';
+
+test('generateAuthCode returns a 6-digit string', () => {
+  const code = generateAuthCode();
+  assert.match(code, /^\d{6}$/);
+});
+
+test('generateApiKeyRaw uses kk_ prefix', () => {
+  const key = generateApiKeyRaw();
+  assert.ok(isApiKeyFormat(key));
+});
+
+test('hashSecret is deterministic for the same input', async () => {
+  const a = await hashSecret('hello');
+  const b = await hashSecret('hello');
+  assert.equal(a, b);
+});
+
+test('normalizeAgentCapabilities accepts valid capability rows', () => {
+  const result = normalizeAgentCapabilities([
+    { id: 'check_inventory', description: 'Read inventory levels', label: 'Check inventory' },
+  ]);
+  assert.deepEqual(result, [
+    {
+      id: 'check_inventory',
+      description: 'Read inventory levels',
+      label: 'Check inventory',
+    },
+  ]);
+});
+
+test('normalizeAgentCapabilities rejects invalid payloads', () => {
+  assert.equal(normalizeAgentCapabilities('nope'), null);
+  assert.equal(normalizeAgentCapabilities([{ id: '', description: 'x' }]), null);
+});


### PR DESCRIPTION
The sign-in code email (sent by request-code for both UI and API users) incorrectly instructed people to visit the raw POST-only API endpoint at /api/auth/agent/verify-code.

For the common human flow via the Onyx agents landing component (onyx-agents.tsx), users enter the code in the on-page form after receiving the email.

Updated the email body text to a neutral, accurate instruction that works for the UI experience (and doesn't mislead API users either).

Also removed the now-dead `appUrl` const (only usage was in the old text).

- Smallest possible safe change (one string + dead code removal).
- No behavior or security impact.
- Verified with `npx eslint src/lib/agent-email.ts` (clean for the file; pre-existing warnings elsewhere unchanged).
- Pre-push lint ran on push (no new errors).

This is the next high-confidence UX bug surfaced while the agent-trust-cards feature (email-code auth) was the most recent landed work.